### PR TITLE
Fix prefs view: libsoup version mismatch

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -81,10 +81,7 @@ class GEWallpaperIndicator extends panelMenu.Button {
         this.link = "https://earthview.withgoogle.com/";
         this.imageid = 0;
         this.refreshdue = 0; // UNIX timestamp when next refresh is due
-        this.httpSession = null;
-
-        // create libSoup session for http requests
-        this._initSoup();
+        this.httpSession = Utils.initSoup(); // create libSoup session for http requests
 
         this._settings.connect('changed::hide', () => {
             getActorCompat(this).visible = !this._settings.get_boolean('hide');
@@ -154,13 +151,6 @@ class GEWallpaperIndicator extends panelMenu.Button {
             log("no previous state to restore... (first run?)");
             this._restartTimeout(60); // wait 60 seconds before performing refresh
         }
-    }
-
-    // create soup Session
-    _initSoup() {
-        this.httpSession = new Soup.Session();
-        this.httpSession.user_agent = 'User-Agent: Mozilla/5.0 (GNOME Shell/' + imports.misc.config.PACKAGE_VERSION + '; Linux; +https://github.com/neffo/earth-view-wallpaper-gnome-extension ) Google Earth Wallpaper Gnome Extension/' + Me.metadata.version;
-
     }
 
     _setMenuConnections() {

--- a/prefs.js
+++ b/prefs.js
@@ -8,7 +8,6 @@
 // Based on GNOME shell extension NASA APOD by Elia Argentieri https://github.com/Elinvention/gnome-shell-extension-nasa-apod
 /*global imports, log*/
 
-imports.gi.versions.Soup = '2.4';
 const {Gtk, Gio, GLib, Soup, Gdk} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -80,8 +79,7 @@ function buildPrefsWidget() {
     let notifySwitch = buildable.get_object('notify');
     
     // enable change log access
-    httpSession = new Soup.SessionAsync();
-    Soup.Session.prototype.add_feature.call(httpSession, new Soup.ProxyResolverDefault());
+    httpSession = Utils.initSoup();
 
     // Indicator
     settings.bind('hide', hideSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);

--- a/prefs.js
+++ b/prefs.js
@@ -8,7 +8,7 @@
 // Based on GNOME shell extension NASA APOD by Elia Argentieri https://github.com/Elinvention/gnome-shell-extension-nasa-apod
 /*global imports, log*/
 
-const {Gtk, Gio, GLib, Soup, Gdk} = imports.gi;
+const {Gtk, Gio, GLib, Gdk} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;

--- a/utils.js
+++ b/utils.js
@@ -54,6 +54,12 @@ function clamp_value(value, min, max) {
 	return Math.min(Math.max(value, min), max);
 }
 
+function initSoup() {
+    let httpSession = new Soup.Session();
+    httpSession.user_agent = 'User-Agent: Mozilla/5.0 (GNOME Shell/' + imports.misc.config.PACKAGE_VERSION + '; Linux; +https://github.com/neffo/earth-view-wallpaper-gnome-extension ) Google Earth Wallpaper Gnome Extension/' + Me.metadata.version;
+    return httpSession;
+}
+
 function fetch_change_log(version, label, httpSession) {
 	// create an http message
 	let url = gitreleaseurl + "v" + version;


### PR DESCRIPTION
While other parts of the code migrated to the correct version, extension settings remained, and that caused breakage on newer GNOME versions.